### PR TITLE
Fix build with automake >= 1.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT([submarine], [0.1.2], [blaz.tomazic@gmail.com])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([foreign -Wall -Werror])
+AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-extra-portability])
 AM_SILENT_RULES([yes])
 AC_CONFIG_FILES([Makefile
 				 lib/Makefile


### PR DESCRIPTION
According to the `NEWS` in 1.12:

```
- The warnings in the category 'extra-portability' are now enabled by
  '-Wall'.  In previous versions, one has to use '-Wextra-portability'
  to enable them.
```

Fixes this error message when running `autogen.sh`:

```
automake: warnings are treated as errors
/usr/share/automake-1.12/am/ltlibrary.am: warning: 'libsubmarine.la': linking libtool libraries using a non-POSIX
/usr/share/automake-1.12/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
lib/Makefile.am:1:   while processing Libtool library 'libsubmarine.la'
lib/Makefile.am: installing 'build-aux/depcomp'
autoreconf: automake failed with exit status: 1
```
